### PR TITLE
Better docs

### DIFF
--- a/documentation.lisp
+++ b/documentation.lisp
@@ -9,7 +9,7 @@
 
 ;; cell.lisp
 (docs:define-docs
-  (padding
+  (cl:function padding
     "Padding in the number of pixels to use between the cell edge and the item.")
 
   (type cell
@@ -35,23 +35,23 @@ Use the corresponding keywords for the widget places."))
 
 ;; container.lisp
 (docs:define-docs
-  (map-widgets
+  (cl:function map-widgets
     "Map the function over the container's widgets.
 The mapping order is in sequence with the widget positions.")
 
-  (map-items
+  (cl:function map-items
     "Map the function over the container's items.
 The mapping order is in sequence with the item positions.")
 
-  (ensure-widget-order
+  (cl:function ensure-widget-order
     "Make sure that the widgets of the container are in the right order.
 This may change the widget's positions.")
 
-  (sorting
+  (cl:function sorting
     "The function used for sorting the container. If NIL, no sorting is applied.
 The function must accept two arguments to compare.")
 
-  (widgets
+  (cl:function widgets
     "The direct widgets stored in the container.
 You should not used this unless you are implementing a container yourself, or know
 what you are doing, as the data structure is not necessarily safe to use directly,
@@ -141,7 +141,7 @@ See MIME-DATA-WITH-OBJECT
 See DRAGGABLE
 See DROP-ACCEPTABLE-P
 See DROP")
-  (drop-acceptable-p
+  (cl:function drop-acceptable-p
     "Whether it is possible to drop ITEM onto TARGET.
 
 Syntax: (drop-acceptable-p item target)
@@ -160,7 +160,7 @@ See MIME-DATA-WITH-OBJECT
 See DRAGGABLE
 See DROP-TARGET
 See DROP")
-  (drop
+  (cl:function drop
     "Implements logic to be run after an item is dropped.
 
 Syntax: (drop item target)
@@ -176,18 +176,18 @@ See DROP-ACCEPTABLE-P"))
 
 ;; draggable.lisp
 (docs:define-docs
-  (dragging
+  (cl:function dragging
     "Whether the draggable is currently being dragged.")
 
-  (drag-start
+  (cl:function drag-start
     "Called whenever the draggable is beginning to be dragged.
 This usually happens during a mouse-press event.")
 
-  (drag
+  (cl:function drag
     "Called whenever the draggable is being dragged around.
 This usually happens during a mouse-move event.")
 
-  (drag-end
+  (cl:function drag-end
     "Called whenever the draggable has stopped being dragged.
 This usually happens during a mouse-release event.")
 
@@ -208,14 +208,14 @@ See EXECUTE
 See EXECUTE-IN-GUI
 See WITH-BODY-IN-GUI")
 
-  (execute
+  (cl:function execute
     "Performs the execution of an object.
 
 An ABORT restart is always available during the execution of this method.
 
 A standard method for FUNCTION objects exists.")
 
-  (execute-in-gui
+  (cl:function execute-in-gui
     "Schedules the execution to be executed within the executable's GUI thread.
 
 When exactly the execution happens cannot be predetermined. However, it should
@@ -231,95 +231,95 @@ See EXECUTE-IN-GUI"))
 
 ;; items.lisp
 (docs:define-docs
-  (container
+  (cl:function container
     "The container of the item-widget.
 
 See ITEM-WIDGET")
 
-  (widget-item
+  (cl:function widget-item
     "The actual item wrapped by the item-widget.
 
 See ITEM-WIDGET")
 
-  (item-widget
+  (cl:function item-widget
     "Find the item-widget for the given item in the layout.")
 
-  (coerce-item
+  (cl:function coerce-item
     "Create a suitable item-widget for the item.")
 
-  (item-at
+  (cl:function item-at
     "Return the item at the specified place in the layout.")
 
-  (item-position
+  (cl:function item-position
     "Return the position of the item in the layout.
 
 See WIDGET-POSITION")
 
-  (find-item
+  (cl:function find-item
     "Find the item in the layout.
 
 See FIND-WIDGET")
 
-  (add-item
+  (cl:function add-item
     "Add the item to the layout.
 
 See ADD-WIDGET
 See COERCE-ITEM")
 
-  (insert-item
+  (cl:function insert-item
     "Insert the item into the layout at the specified place.
 
 See INSERT-WIDGET
 See COERCE-ITEM")
 
-  (remove-item
+  (cl:function remove-item
     "Remove the item from the layout.
 
 See REMOVE-WIDGET
 See ITEM-WIDGET")
 
-  (remove-item-at
+  (cl:function remove-item-at
     "Remove the item at the specified place in the layout.
 
 See REMOVE-WIDGET")
 
-  (swap-items
+  (cl:function swap-items
     "Swap the two items in their place in the layout.
 Note that the implementation might swap the corresponding item-widget,
 or it may also choose to swap the items in place. As such, the item-widget's
 positions may change, or the actual item-widget of the item may change.")
 
-  (swap-items-at
+  (cl:function swap-items-at
     "Swap the two items at the specified places in the layout.
 
 See SWAP-ITEMS")
 
-  (item-acceptable-p
+  (cl:function item-acceptable-p
     "A predicate to decide whether the item is suitable for inclusion in the widget.")
 
-  (item<
+  (cl:function item<
     "Whether A precedes B.
 Default methods for STRING and NUMBER exist, as well as a general method that simply
 prints the object to a string using PRINC and calls ITEM< again with the results of that.
 
 Add your own methods to this if you need more precise sorting.")
 
-  (item=
+  (cl:function item=
     "Whether A is equal to B.
 Default methods for STRING and NUMBER exist, as well as a general method that simply
 prints the object to a string using PRINC and calls ITEM= again with the results of that.
 
 Add your own methods to this if you need more precise sorting.")
 
-  (item>
+  (cl:function item>
     "Whether A follows B.
 Uses ITEM< and ITEM= to calculate the result. You should not need to add methods to this.")
 
-  (item<=
+  (cl:function item<=
     "Whether A precedes B.
 Uses ITEM< and ITEM= to calculate the result. You should not need to add methods to this.")
 
-  (item>=
+  (cl:function item>=
     "Whether A follows B.
 Uses ITEM< and ITEM= to calculate the result. You should not need to add methods to this.")
 
@@ -343,41 +343,41 @@ See QTOOLS:DEFINE-MENU"))
 
 ;; layout.lisp
 (docs:define-docs
-  (widget
+  (cl:function widget
     "Returns the widget at the specified place in the layout.")
 
-  (find-widget
+  (cl:function find-widget
     "Find the widget in the layout.
 
 See FIND")
 
-  (widget-position
+  (cl:function widget-position
     "Find the position of the widget in the layout.
 
 See POSITION")
 
-  (widget-at-point
+  (cl:function widget-at-point
     "See if there is a widget in the layout at the point and return it if it exists.
 POINT can be a cons of X and Y or a QPoint.
 The coordinates have to be relative to the layout.")
 
-  (add-widget
+  (cl:function add-widget
     "Add the widget to the layout.
 The positioning of the widget is completely up to the layout.")
 
-  (insert-widget
+  (cl:function insert-widget
     "Insert the widget at the specified place in the layout.")
 
-  (remove-widget
+  (cl:function remove-widget
     "Remove the widget or the widget at the specified place from the layout.")
 
-  (swap-widgets
+  (cl:function swap-widgets
     "Swap the two widgets or the widgets at the specified places in the layout.")
 
-  (clear-layout
+  (cl:function clear-layout
     "Clear all widgets from the layout.")
 
-  (update
+  (cl:function update
     "Update the layout widgets' geometry.
 
 This is automatically called if the layout receives a layout-request event or is resized.
@@ -388,7 +388,7 @@ ones, you should call this method to ensure the widgets are restored as appropra
 If you subclass a layout, you should implement a method on this to calculate yout layouts
 widgets' geometry properly.")
 
-  (widget-acceptable-p
+  (cl:function widget-acceptable-p
     "Predicate to determine whether the layout accepts the given widget.
 This test is automatically called on all the predefined widget adding functions to make
 sure no bad widgets can be inserted into a layout.
@@ -402,14 +402,14 @@ that don't call out to the standard layout functions.")
 
 ;; listing.lisp
 (docs:define-docs
-  (minimum-row-height
+  (cl:function minimum-row-height
     "Accessor to the minimum row height of the listing.")
 
-  (fixed-row-height
+  (cl:function fixed-row-height
     "Accessor to the fixed row height of the listing.
 If NIL, the row heights are dynamic, otherwise the listing will enforce this height.")
 
-  (draggable
+  (cl:function draggable
     "Accessor to whether widgets are draggable or not.")
 
   (type listing
@@ -422,7 +422,7 @@ Unlike the QListWidget, this allows adding actual widgets, not just strings.")
 
 ;; mouse-propagator.lisp
 (docs:define-docs
-  (target
+  (cl:function target
     "The target to send the propagated mouse events to.")
 
   (type mouse-propagator
@@ -431,16 +431,16 @@ This implements an event filter. To catch the events, use QObject::installEventF
 
 ;; panel-container.lisp
 (docs:define-docs
-  (iconified-p
+  (cl:function iconified-p
     "Accessor to whether the panel-container is iconified or not.
 If iconified, the panels are not actually shown, only their titles or icons.")
 
-  (iconify
+  (cl:function iconify
     "Iconify the panel-container.
 
 See ICONFIFIED-P")
 
-  (deiconify
+  (cl:function deiconify
     "Deiconify the panel-container.
 
 See ICONFIFIED-P")
@@ -451,48 +451,48 @@ Supports iconifying, rearranging of the panels, and vertical or horizontal orien
 
 ;; panel.lisp
 (docs:define-docs
-  (title
+  (cl:function title
     "The title displayed for the panel.")
 
-  (detachable-p
+  (cl:function detachable-p
     "Accessor to whether the panel is detachable.")
 
-  (collapsable-p
+  (cl:function collapsable-p
     "Accessor to whether the panel is collapsable.")
 
-  (titlebar-shown-p
+  (cl:function titlebar-shown-p
     "Accessor to whether the panel's titlebar is visible.")
 
-  (attached-p
+  (cl:function attached-p
     "Accessor to whether the panel is attached.
 
 See ATTACH
 See DETACH")
 
-  (collapsed-p
+  (cl:function collapsed-p
     "Accessor to whether the panel is collapsed.
 
 See COLLAPSE
 See EXPAND")
 
-  (attach
+  (cl:function attach
     "Tell the panel to attach itself to a container.
 If NIL is passed as the container, the panel will try to use the last container it has been
 attached to to attach to again. If no container is given or no previous container exists,
 an error is signalled. Panels can only be attached to one container at a time.")
 
-  (detach
+  (cl:function detach
     "Tell the panel to detach itself from a container.
 If it is not currently attached to anything, an error is signalled. The panel will remember
 the container it has been attached to so it can easily be reattached later.")
 
-  (expand
+  (cl:function expand
     "Make the panel's center widget visible.")
 
-  (collapse
+  (cl:function collapse
     "Make the panel's center widget invisible.")
 
-  (exit
+  (cl:function exit
     "Close the panel.")
 
   (type panel
@@ -502,7 +502,7 @@ should be able to freely arrange to their liking."))
 
 ;; repaintable.lisp
 (docs:define-docs
-  (repaint
+  (cl:function repaint
     "Cause the repaintable to be repainted.
 Unlike QWidget::repaint, this method is safe to be called from any thread as it will use a
 signal to reach the main thread in which drawing events are permitted.")
@@ -514,13 +514,13 @@ See REPAINT"))
 
 ;; selectable.lisp
 (docs:define-docs
-  (active-widget
+  (cl:function active-widget
     "Accessor for the currently active widget on the layout.")
 
-  (active-item
+  (cl:function active-item
     "Accessor for the currently active item on the layout.")
 
-  (selectable
+  (cl:function selectable
     "Accessor for whether selecting a widget/item is allowed.")
 
   (type selectable-layout
@@ -531,16 +531,16 @@ See REPAINT"))
 
 ;; slider.lisp
 (docs:define-docs
-  (maximum
+  (cl:function maximum
     "Accessor for the maximum of the slider.")
 
-  (minimum
+  (cl:function minimum
     "Accessor for the minimum of the slider.")
 
-  (stepping
+  (cl:function stepping
     "Accessor for the step size of the slider.")
 
-  (default
+  (cl:function default
     "Accessor for the slider's default value, if any.")
 
   (type double-slider
@@ -562,13 +562,13 @@ See DEFAULT"))
 
 ;; splitter.lisp
 (docs:define-docs
-  (resize-widget
+  (cl:function resize-widget
     "Resize the layout's widget to the given size.")
 
-  (orientation
+  (cl:function orientation
     "Accessor for the layout's orientation, must be one of :vertical or :horizontal.")
 
-  (handle-size
+  (cl:function handle-size
     "Accessor for the size of a splitter's handle.")
 
   (type splitter
@@ -576,7 +576,7 @@ See DEFAULT"))
 
 ;; toolkit.lisp
 (docs:define-docs
-  (call-with-translation
+  (cl:function call-with-translation
     "Call the function while translating the painter by the target.
 
 See QPainter::translate")
@@ -586,17 +586,17 @@ See QPainter::translate")
 
 See CALL-WITH-TRANSLATION")
 
-  (color-to-rgba
+  (cl:function color-to-rgba
     "Turns an rgba quadruplet into an integer.")
 
-  (rgba-to-color
+  (cl:function rgba-to-color
     "Turns an integer into an rgba quadruplet.")
 
-  (c
+  (cl:function c
     "Returns a corresponding QColor object.
 Note that these objects are cached. You should never modify them.")
 
-  (coerce-color
+  (cl:function coerce-color
     "Coerce the color into a QColor object.
 Can be either a QColor, a list of the R G B and A components, or an RGBA integer.
 If not a direct QColor, the value is resolved as per C.

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -7,103 +7,95 @@
 (in-package #:org.shirakumo.qtools.ui)
 (in-readtable :qtools)
 
-(defmacro setdocs (&body pairs)
-  `(progn
-     ,@(loop for (var doc) in pairs
-             collect (destructuring-bind (var &optional (type 'cl:function))
-                         (if (listp var) var (list var))
-                       `(setf (documentation ',var ',type) ,doc)))))
-
-
 ;; cell.lisp
-(setdocs
+(docs:define-docs
   (padding
-   "Padding in the number of pixels to use between the cell edge and the item.")
+    "Padding in the number of pixels to use between the cell edge and the item.")
 
-  ((cell type)
-   "A cell is a generic item container that is selectable and draggable."))
+  (type cell
+    "A cell is a generic item container that is selectable and draggable."))
 
 ;; color-sliders.lisp
-(setdocs
-  ((rgb-color-slider type)
-   "A widget for an RGB sliders color chooser.")
-  ((hsv-color-slider type)
-   "A widget for an HSV sliders color chooser."))
+(docs:define-docs
+  (type rgb-color-slider
+    "A widget for an RGB sliders color chooser.")
+  (type hsv-color-slider
+    "A widget for an HSV sliders color chooser."))
 
 ;; color-triangle.lisp
-(setdocs
-  ((color-triangle type)
-   "A widget for an HSV colour wheel triangle as often used in graphics applications."))
+(docs:define-docs
+  (type color-triangle
+    "A widget for an HSV colour wheel triangle as often used in graphics applications."))
 
 ;; compass.lisp
-(setdocs
-  ((compass type)
-   "A layout widget that aligns items North, East, South, West, and Center.
+(docs:define-docs
+  (type compass
+    "A layout widget that aligns items North, East, South, West, and Center.
 Use the corresponding keywords for the widget places."))
 
 ;; container.lisp
-(setdocs
+(docs:define-docs
   (map-widgets
-   "Map the function over the container's widgets.
+    "Map the function over the container's widgets.
 The mapping order is in sequence with the widget positions.")
 
   (map-items
-   "Map the function over the container's items.
+    "Map the function over the container's items.
 The mapping order is in sequence with the item positions.")
 
   (ensure-widget-order
-   "Make sure that the widgets of the container are in the right order.
+    "Make sure that the widgets of the container are in the right order.
 This may change the widget's positions.")
 
   (sorting
-   "The function used for sorting the container. If NIL, no sorting is applied.
+    "The function used for sorting the container. If NIL, no sorting is applied.
 The function must accept two arguments to compare.")
 
   (widgets
-   "The direct widgets stored in the container.
+    "The direct widgets stored in the container.
 You should not used this unless you are implementing a container yourself, or know
 what you are doing, as the data structure is not necessarily safe to use directly,
 or even specified to be of a certain type.")
 
-  ((do-widgets)
-   "Loop over the container's widgets.
+  (cl:function do-widgets
+    "Loop over the container's widgets.
 
 See MAP-WIDGETS")
 
-  ((do-items)
-   "Loop over the container's items.
+  (cl:function do-items
+    "Loop over the container's items.
 
 See MAP-ITEMS")
 
-  ((container type)
-   "A simple container to hold a list of widgets and manage the various layout functions.
+  (type container
+    "A simple container to hold a list of widgets and manage the various layout functions.
 This does not actually concern itself with arranging the widgets and only handles
 the internal representation of the widgets. As such, this class is to be used as
 a superclass for an actual layout that then takes care of the widget arrangement.")
 
-  ((sorted-container type)
-   "A container that also supports automatic sorting of the widgets.
+  (type sorted-container
+    "A container that also supports automatic sorting of the widgets.
 
 See CONTAINER
 See SORTING")
 
-  ((item-container type)
-   "A container that uses item containers instead of direct widgets.
+  (type item-container
+    "A container that uses item containers instead of direct widgets.
 
 See CONTAINER
 See ITEM-LAYOUT")
 
-  ((sorted-item-container type)
-   "An item-container that also supports automatic sorting of the items.
+  (type sorted-item-container
+    "An item-container that also supports automatic sorting of the items.
 
 See ITEM-CONTAINER
 See SORTED-CONTAINER"))
 
 ;; drag-and-drop.lisp
 
-(setdocs
-  ((mime-data-with-object type)
-   "Subclass of QMimeData capable of holding Lisp objects.
+(docs:define-docs
+  (type mime-data-with-object
+    "Subclass of QMimeData capable of holding Lisp objects.
 
 This class is a direct subclass of QMimeData with two modifications:
 
@@ -117,8 +109,8 @@ a part of this drag and drop framework. Instead, the user should subclass DRAGGA
 
 See DRAGGABLE
 See DROP-TARGET")
-  ((draggable type)
-   "Superclass of all objects that are draggable.
+  (type draggable
+    "Superclass of all objects that are draggable.
 
 This class should be subclassed by all widgets that are meant to be draggable.
 Mouse-clicking an instance of this class will initiate drag behaviour.
@@ -133,8 +125,8 @@ See MIME-DATA-WITH-OBJECT
 See DROP-TARGET
 See DROP-ACCEPTABLE-P
 See DROP")
-  ((drop-target type)
-   "Superclass of all objects that accept drops.
+  (type drop-target
+    "Superclass of all objects that accept drops.
 
 This class should be subclassed by all widgets that are meant to accept drops. Dropping a
 drag over this widget will initiate drop behaviour.
@@ -150,7 +142,7 @@ See DRAGGABLE
 See DROP-ACCEPTABLE-P
 See DROP")
   (drop-acceptable-p
-   "Whether it is possible to drop ITEM onto TARGET.
+    "Whether it is possible to drop ITEM onto TARGET.
 
 Syntax: (drop-acceptable-p item target)
 
@@ -169,7 +161,7 @@ See DRAGGABLE
 See DROP-TARGET
 See DROP")
   (drop
-   "Implements logic to be run after an item is dropped.
+    "Implements logic to be run after an item is dropped.
 
 Syntax: (drop item target)
 
@@ -183,24 +175,24 @@ See DROP-TARGET
 See DROP-ACCEPTABLE-P"))
 
 ;; draggable.lisp
-(setdocs
+(docs:define-docs
   (dragging
-   "Whether the draggable is currently being dragged.")
+    "Whether the draggable is currently being dragged.")
 
   (drag-start
-   "Called whenever the draggable is beginning to be dragged.
+    "Called whenever the draggable is beginning to be dragged.
 This usually happens during a mouse-press event.")
 
   (drag
-   "Called whenever the draggable is being dragged around.
+    "Called whenever the draggable is being dragged around.
 This usually happens during a mouse-move event.")
 
   (drag-end
-   "Called whenever the draggable has stopped being dragged.
+    "Called whenever the draggable has stopped being dragged.
 This usually happens during a mouse-release event.")
 
-  ((draggable type)
-   "A helper class to be used when you need to support dragging of your widget.
+  (type draggable
+    "A helper class to be used when you need to support dragging of your widget.
 
 See DRAGGING
 See DRAG-START
@@ -208,23 +200,23 @@ See DRAG
 See DRAG-END"))
 
 ;; executable.lisp
-(setdocs
-  ((executable type)
-   "A qobject superclass that allows running functions within the GUI thread.
+(docs:define-docs
+  (type executable
+    "A qobject superclass that allows running functions within the GUI thread.
 
 See EXECUTE
 See EXECUTE-IN-GUI
 See WITH-BODY-IN-GUI")
 
   (execute
-   "Performs the execution of an object.
+    "Performs the execution of an object.
 
 An ABORT restart is always available during the execution of this method.
 
 A standard method for FUNCTION objects exists.")
 
   (execute-in-gui
-   "Schedules the execution to be executed within the executable's GUI thread.
+    "Schedules the execution to be executed within the executable's GUI thread.
 
 When exactly the execution happens cannot be predetermined. However, it should
 be approximately whenever the Qt event loop processes its next batch of events.
@@ -232,161 +224,161 @@ be approximately whenever the Qt event loop processes its next batch of events.
 See EXECUTABLE
 See EXECUTE")
 
-  ((with-body-in-gui)
-   "Convenience wrapper macro around EXECUTE-IN-GUI
+  (cl:function with-body-in-gui
+    "Convenience wrapper macro around EXECUTE-IN-GUI
 
 See EXECUTE-IN-GUI"))
 
 ;; items.lisp
-(setdocs
+(docs:define-docs
   (container
-   "The container of the item-widget.
+    "The container of the item-widget.
 
 See ITEM-WIDGET")
 
   (widget-item
-   "The actual item wrapped by the item-widget.
+    "The actual item wrapped by the item-widget.
 
 See ITEM-WIDGET")
 
   (item-widget
-   "Find the item-widget for the given item in the layout.")
+    "Find the item-widget for the given item in the layout.")
 
   (coerce-item
-   "Create a suitable item-widget for the item.")
+    "Create a suitable item-widget for the item.")
 
   (item-at
-   "Return the item at the specified place in the layout.")
+    "Return the item at the specified place in the layout.")
 
   (item-position
-   "Return the position of the item in the layout.
+    "Return the position of the item in the layout.
 
 See WIDGET-POSITION")
 
   (find-item
-   "Find the item in the layout.
+    "Find the item in the layout.
 
 See FIND-WIDGET")
 
   (add-item
-   "Add the item to the layout.
+    "Add the item to the layout.
 
 See ADD-WIDGET
 See COERCE-ITEM")
 
   (insert-item
-   "Insert the item into the layout at the specified place.
+    "Insert the item into the layout at the specified place.
 
 See INSERT-WIDGET
 See COERCE-ITEM")
 
   (remove-item
-   "Remove the item from the layout.
+    "Remove the item from the layout.
 
 See REMOVE-WIDGET
 See ITEM-WIDGET")
 
   (remove-item-at
-   "Remove the item at the specified place in the layout.
+    "Remove the item at the specified place in the layout.
 
 See REMOVE-WIDGET")
 
   (swap-items
-   "Swap the two items in their place in the layout.
+    "Swap the two items in their place in the layout.
 Note that the implementation might swap the corresponding item-widget,
 or it may also choose to swap the items in place. As such, the item-widget's
 positions may change, or the actual item-widget of the item may change.")
 
   (swap-items-at
-   "Swap the two items at the specified places in the layout.
+    "Swap the two items at the specified places in the layout.
 
 See SWAP-ITEMS")
 
   (item-acceptable-p
-   "A predicate to decide whether the item is suitable for inclusion in the widget.")
+    "A predicate to decide whether the item is suitable for inclusion in the widget.")
 
   (item<
-   "Whether A precedes B.
+    "Whether A precedes B.
 Default methods for STRING and NUMBER exist, as well as a general method that simply
 prints the object to a string using PRINC and calls ITEM< again with the results of that.
 
 Add your own methods to this if you need more precise sorting.")
 
   (item=
-   "Whether A is equal to B.
+    "Whether A is equal to B.
 Default methods for STRING and NUMBER exist, as well as a general method that simply
 prints the object to a string using PRINC and calls ITEM= again with the results of that.
 
 Add your own methods to this if you need more precise sorting.")
 
   (item>
-   "Whether A follows B.
+    "Whether A follows B.
 Uses ITEM< and ITEM= to calculate the result. You should not need to add methods to this.")
 
   (item<=
-   "Whether A precedes B.
+    "Whether A precedes B.
 Uses ITEM< and ITEM= to calculate the result. You should not need to add methods to this.")
 
   (item>=
-   "Whether A follows B.
+    "Whether A follows B.
 Uses ITEM< and ITEM= to calculate the result. You should not need to add methods to this.")
 
-  ((item-layout type)
-   "A layout to contain items.
+  (type item-layout
+    "A layout to contain items.
 
 See LAYOUT")
 
-  ((item-widget type)
-   "A widget to contain an item.
+  (type item-widget
+    "A widget to contain an item.
 Depending on the item type, an item may or may not be contained in multiple item-widgets
 at the same time. However, an item-widget itself can only be contained once and only in
 one layout at a time."))
 
 ;; keychord-editor.lisp
-(setdocs
-  ((keychord-editor type)
-   "A simple dialog to allow dynamic changing of keychords as defined in a menu definition.
+(docs:define-docs
+  (type keychord-editor
+    "A simple dialog to allow dynamic changing of keychords as defined in a menu definition.
 
 See QTOOLS:DEFINE-MENU"))
 
 ;; layout.lisp
-(setdocs
+(docs:define-docs
   (widget
-   "Returns the widget at the specified place in the layout.")
+    "Returns the widget at the specified place in the layout.")
 
   (find-widget
-   "Find the widget in the layout.
+    "Find the widget in the layout.
 
 See FIND")
 
   (widget-position
-   "Find the position of the widget in the layout.
+    "Find the position of the widget in the layout.
 
 See POSITION")
 
   (widget-at-point
-   "See if there is a widget in the layout at the point and return it if it exists.
+    "See if there is a widget in the layout at the point and return it if it exists.
 POINT can be a cons of X and Y or a QPoint.
 The coordinates have to be relative to the layout.")
 
   (add-widget
-   "Add the widget to the layout.
+    "Add the widget to the layout.
 The positioning of the widget is completely up to the layout.")
 
   (insert-widget
-   "Insert the widget at the specified place in the layout.")
+    "Insert the widget at the specified place in the layout.")
 
   (remove-widget
-   "Remove the widget or the widget at the specified place from the layout.")
+    "Remove the widget or the widget at the specified place from the layout.")
 
   (swap-widgets
-   "Swap the two widgets or the widgets at the specified places in the layout.")
+    "Swap the two widgets or the widgets at the specified places in the layout.")
 
   (clear-layout
-   "Clear all widgets from the layout.")
+    "Clear all widgets from the layout.")
 
   (update
-   "Update the layout widgets' geometry.
+    "Update the layout widgets' geometry.
 
 This is automatically called if the layout receives a layout-request event or is resized.
 It's also automatically called on the various layout modifying operations.
@@ -397,7 +389,7 @@ If you subclass a layout, you should implement a method on this to calculate you
 widgets' geometry properly.")
 
   (widget-acceptable-p
-   "Predicate to determine whether the layout accepts the given widget.
+    "Predicate to determine whether the layout accepts the given widget.
 This test is automatically called on all the predefined widget adding functions to make
 sure no bad widgets can be inserted into a layout.
 
@@ -405,162 +397,162 @@ You should add methods to this to either further restrict or permit further widg
 You should call this to check for permission if you add new layout manipulating functions
 that don't call out to the standard layout functions.")
 
-  ((layout type)
-   "Superclass for all custom layout widgets."))
+  (type layout
+    "Superclass for all custom layout widgets."))
 
 ;; listing.lisp
-(setdocs
+(docs:define-docs
   (minimum-row-height
-   "Accessor to the minimum row height of the listing.")
+    "Accessor to the minimum row height of the listing.")
 
   (fixed-row-height
-   "Accessor to the fixed row height of the listing.
+    "Accessor to the fixed row height of the listing.
 If NIL, the row heights are dynamic, otherwise the listing will enforce this height.")
 
   (draggable
-   "Accessor to whether widgets are draggable or not.")
+    "Accessor to whether widgets are draggable or not.")
 
-  ((listing type)
-   "Replacement for the QListWidget.
+  (type listing
+    "Replacement for the QListWidget.
 Allows sorting, dragging, selecting, and of course dynamic modification of the contents.
 Unlike the QListWidget, this allows adding actual widgets, not just strings.")
 
-  ((listing-item type)
-   "The item container for the listing container."))
+  (type listing-item
+    "The item container for the listing container."))
 
 ;; mouse-propagator.lisp
-(setdocs
+(docs:define-docs
   (target
-   "The target to send the propagated mouse events to.")
+    "The target to send the propagated mouse events to.")
 
-  ((mouse-propagator type)
-   "A helper class that propagates mouse events somewhere else, by default to itself.
+  (type mouse-propagator
+    "A helper class that propagates mouse events somewhere else, by default to itself.
 This implements an event filter. To catch the events, use QObject::installEventFilter."))
 
 ;; panel-container.lisp
-(setdocs
+(docs:define-docs
   (iconified-p
-   "Accessor to whether the panel-container is iconified or not.
+    "Accessor to whether the panel-container is iconified or not.
 If iconified, the panels are not actually shown, only their titles or icons.")
 
   (iconify
-   "Iconify the panel-container.
+    "Iconify the panel-container.
 
 See ICONFIFIED-P")
 
   (deiconify
-   "Deiconify the panel-container.
+    "Deiconify the panel-container.
 
 See ICONFIFIED-P")
 
-  ((panel-container type)
-   "A container for panels.
+  (type panel-container
+    "A container for panels.
 Supports iconifying, rearranging of the panels, and vertical or horizontal orientation."))
 
 ;; panel.lisp
-(setdocs
+(docs:define-docs
   (title
-   "The title displayed for the panel.")
+    "The title displayed for the panel.")
 
   (detachable-p
-   "Accessor to whether the panel is detachable.")
+    "Accessor to whether the panel is detachable.")
 
   (collapsable-p
-   "Accessor to whether the panel is collapsable.")
+    "Accessor to whether the panel is collapsable.")
 
   (titlebar-shown-p
-   "Accessor to whether the panel's titlebar is visible.")
+    "Accessor to whether the panel's titlebar is visible.")
 
   (attached-p
-   "Accessor to whether the panel is attached.
+    "Accessor to whether the panel is attached.
 
 See ATTACH
 See DETACH")
 
   (collapsed-p
-   "Accessor to whether the panel is collapsed.
+    "Accessor to whether the panel is collapsed.
 
 See COLLAPSE
 See EXPAND")
 
   (attach
-   "Tell the panel to attach itself to a container.
+    "Tell the panel to attach itself to a container.
 If NIL is passed as the container, the panel will try to use the last container it has been
 attached to to attach to again. If no container is given or no previous container exists,
 an error is signalled. Panels can only be attached to one container at a time.")
 
   (detach
-   "Tell the panel to detach itself from a container.
+    "Tell the panel to detach itself from a container.
 If it is not currently attached to anything, an error is signalled. The panel will remember
 the container it has been attached to so it can easily be reattached later.")
 
   (expand
-   "Make the panel's center widget visible.")
+    "Make the panel's center widget visible.")
 
   (collapse
-   "Make the panel's center widget invisible.")
+    "Make the panel's center widget invisible.")
 
   (exit
-   "Close the panel.")
+    "Close the panel.")
 
-  ((panel type)
-   "A dockable and collapsible panel to contain a widget.
+  (type panel
+    "A dockable and collapsible panel to contain a widget.
 Useful in situations where you want to build a UI that contains several parts that the user
 should be able to freely arrange to their liking."))
 
 ;; repaintable.lisp
-(setdocs
+(docs:define-docs
   (repaint
-   "Cause the repaintable to be repainted.
+    "Cause the repaintable to be repainted.
 Unlike QWidget::repaint, this method is safe to be called from any thread as it will use a
 signal to reach the main thread in which drawing events are permitted.")
 
-  ((repaintable type)
-   "A widget that is safely repaintable by offering a method and signal to cause a repaint in the main thread.
+  (type repaintable
+    "A widget that is safely repaintable by offering a method and signal to cause a repaint in the main thread.
 
 See REPAINT"))
 
 ;; selectable.lisp
-(setdocs
+(docs:define-docs
   (active-widget
-   "Accessor for the currently active widget on the layout.")
+    "Accessor for the currently active widget on the layout.")
 
   (active-item
-   "Accessor for the currently active item on the layout.")
+    "Accessor for the currently active item on the layout.")
 
   (selectable
-   "Accessor for whether selecting a widget/item is allowed.")
+    "Accessor for whether selecting a widget/item is allowed.")
 
-  ((selectable-layout type)
-   "An item-layout that allows selecting a certain item.")
+  (type selectable-layout
+    "An item-layout that allows selecting a certain item.")
 
-  ((selectable-item type)
-   "An item that permits being selected."))
+  (type selectable-item
+    "An item that permits being selected."))
 
 ;; slider.lisp
-(setdocs
+(docs:define-docs
   (maximum
-   "Accessor for the maximum of the slider.")
+    "Accessor for the maximum of the slider.")
 
   (minimum
-   "Accessor for the minimum of the slider.")
+    "Accessor for the minimum of the slider.")
 
   (stepping
-   "Accessor for the step size of the slider.")
+    "Accessor for the step size of the slider.")
 
   (default
-   "Accessor for the slider's default value, if any.")
+    "Accessor for the slider's default value, if any.")
 
-  ((double-slider type)
-   "Qt does not provide a floating-point slider, hence this.
+  (type double-slider
+    "Qt does not provide a floating-point slider, hence this.
 It uses a standard slider, but uses an internal divisor to achieve floating point values.
 
 See MAXIMUM
 See MINIMUM
 See STEPPING")
 
-  ((slider type)
-   "A neat slider widget that combines a double-slider, a spin box, and a potential defaulting button.
+  (type slider
+    "A neat slider widget that combines a double-slider, a spin box, and a potential defaulting button.
 If the default is NIL, no button is displayed.
 
 See MAXIMUM
@@ -569,43 +561,43 @@ See STEPPING
 See DEFAULT"))
 
 ;; splitter.lisp
-(setdocs
+(docs:define-docs
   (resize-widget
-   "Resize the layout's widget to the given size.")
+    "Resize the layout's widget to the given size.")
 
   (orientation
-   "Accessor for the layout's orientation, must be one of :vertical or :horizontal.")
+    "Accessor for the layout's orientation, must be one of :vertical or :horizontal.")
 
   (handle-size
-   "Accessor for the size of a splitter's handle.")
+    "Accessor for the size of a splitter's handle.")
 
-  ((splitter type)
-   "Similar to QSplitter, but instead of distributing all available space, only uses up and extends to as much space as is needed by its widgets."))
+  (type splitter
+    "Similar to QSplitter, but instead of distributing all available space, only uses up and extends to as much space as is needed by its widgets."))
 
 ;; toolkit.lisp
-(setdocs
+(docs:define-docs
   (call-with-translation
-   "Call the function while translating the painter by the target.
+    "Call the function while translating the painter by the target.
 
 See QPainter::translate")
 
-  ((with-translation)
-   "Convenience macro around call-with-translation
+  (cl:function with-translation
+    "Convenience macro around call-with-translation
 
 See CALL-WITH-TRANSLATION")
 
   (color-to-rgba
-   "Turns an rgba quadruplet into an integer.")
+    "Turns an rgba quadruplet into an integer.")
 
   (rgba-to-color
-   "Turns an integer into an rgba quadruplet.")
+    "Turns an integer into an rgba quadruplet.")
 
   (c
-   "Returns a corresponding QColor object.
+    "Returns a corresponding QColor object.
 Note that these objects are cached. You should never modify them.")
 
   (coerce-color
-   "Coerce the color into a QColor object.
+    "Coerce the color into a QColor object.
 Can be either a QColor, a list of the R G B and A components, or an RGBA integer.
 If not a direct QColor, the value is resolved as per C.
 

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -19,6 +19,7 @@
 (docs:define-docs
   (type rgb-color-slider
     "A widget for an RGB sliders color chooser.")
+
   (type hsv-color-slider
     "A widget for an HSV sliders color chooser."))
 
@@ -109,6 +110,7 @@ a part of this drag and drop framework. Instead, the user should subclass DRAGGA
 
 See DRAGGABLE
 See DROP-TARGET")
+
   (type draggable
     "Superclass of all objects that are draggable.
 
@@ -125,6 +127,7 @@ See MIME-DATA-WITH-OBJECT
 See DROP-TARGET
 See DROP-ACCEPTABLE-P
 See DROP")
+
   (type drop-target
     "Superclass of all objects that accept drops.
 
@@ -141,6 +144,7 @@ See MIME-DATA-WITH-OBJECT
 See DRAGGABLE
 See DROP-ACCEPTABLE-P
 See DROP")
+
   (cl:function drop-acceptable-p
     "Whether it is possible to drop ITEM onto TARGET.
 
@@ -160,6 +164,7 @@ See MIME-DATA-WITH-OBJECT
 See DRAGGABLE
 See DROP-TARGET
 See DROP")
+
   (cl:function drop
     "Implements logic to be run after an item is dropped.
 

--- a/qtools-ui-base.asd
+++ b/qtools-ui-base.asd
@@ -20,4 +20,5 @@
   :depends-on (:qtools
                :qtcore
                :qtgui
+               :documentation-utils
                :array-utils))


### PR DESCRIPTION
* Use `documentation-utils`
* Explicit documentation types for `cl:function`
* Add newlines where necessary