### PR TITLE
Add FIXED-QTEXTEDIT

### DIFF
--- a/fixed-qtextedit.lisp
+++ b/fixed-qtextedit.lisp
@@ -1,0 +1,27 @@
+#|
+ This file is a part of Qtools-UI
+ (c) 2015 Shirakumo http://tymoon.eu (shinmera@tymoon.eu)
+ Author: Michał "phoe" Herda <phoe@disroot.org>
+|#
+
+(in-package #:org.shirakumo.qtools.ui)
+(in-readtable :qtools)
+
+(define-widget fixed-qtextedit (qtextedit) ())
+
+(define-subwidget (fixed-qtextedit fix-context-menu-widget) (q+:make-qwidget))
+
+(define-override (fixed-qtextedit context-menu-event) (event)
+  ;; I have no idea why it works this way, but it seems to work.
+  (call-next-qmethod)
+  (let ((position (q+:pos event)))
+    ;; Fix cursor position after the context menu disappears.
+    (let* ((cursor (q+:cursor-for-position fixed-qtextedit position)))
+      (setf (q+:text-cursor fixed-qtextedit) cursor))
+    ;; Display the context menu.
+    (with-finalizing ((menu (q+:create-standard-context-menu fixed-qtextedit)))
+      (q+:exec menu (q+:global-pos event)))
+    ;; Work around the bug.
+    (q+:show fix-context-menu-widget)
+    (setf (q+:focus fix-context-menu-widget) 0)
+    (q+:hide fix-context-menu-widget)))

--- a/package.lisp
+++ b/package.lisp
@@ -93,6 +93,9 @@
    #:execute
    #:execute-in-gui
    #:with-body-in-gui)
+  ;; fixed-qtextedit.lisp
+  (:export
+   #:fixed-qtextedit)
   ;; flow-layout.lisp
   (:export
    #:flow-layout)

--- a/qtools-ui-fixed-qtextedit.asd
+++ b/qtools-ui-fixed-qtextedit.asd
@@ -1,0 +1,17 @@
+#|
+ This file is a part of Qtools-UI
+ (c) 2015 Shirakumo http://tymoon.eu (shinmera@tymoon.eu)
+ Author: Michał "phoe" Herda <phoe@disroot.org>
+|#
+
+(asdf:defsystem qtools-ui-fixed-qtextedit
+  :license "Artistic"
+  :author "Michał \"phoe\" Herda <phoe@disroot.org>"
+  :maintainer "Michał \"phoe\" Herda <phoe@disroot.org>"
+  :description "QTextEdit with working context menu - workaround for QTBUG-9592"
+  :homepage "https://Shinmera.github.io/qtools-ui/"
+  :bug-tracker "https://github.com/Shinmera/qtools-ui/issues"
+  :source-control (:git "https://github.com/Shinmera/qtools-ui.git")
+  :serial T
+  :components ((:file "fixed-qtextedit"))
+  :depends-on (:qtools-ui-base))

--- a/qtools-ui.asd
+++ b/qtools-ui.asd
@@ -26,6 +26,7 @@
                :qtools-ui-debugger
                :qtools-ui-drag-and-drop
                :qtools-ui-dialog
+               :qtools-ui-fixed-qtextedit
                :qtools-ui-flow-layout
                :qtools-ui-helpers
                :qtools-ui-keychord-editor


### PR DESCRIPTION
This is a QTextEdit that works around [QTBUG-9592](https://bugreports.qt.io/browse/QTBUG-9592?gerritIssueStatus=All) which breaks the widget when the context menu is invoked.

The name of the widget can be changed, I just haven't come up with a better one yet.