### PR TITLE
Add AUTO-RESIZING-TEXTEDIT

### DIFF
--- a/auto-resizing-textedit.lisp
+++ b/auto-resizing-textedit.lisp
@@ -1,0 +1,61 @@
+#|
+ This file is a part of Qtools-UI
+ (c) 2020 Shirakumo http://tymoon.eu (shinmera@tymoon.eu)
+ Author: Michał "phoe" Herda <phoe@disroot.org>
+
+ This is a port of https://github.com/cameel/auto-resizing-text-edit/
+ by Kamil Śliwak, released under the MIT license.
+|#
+
+(in-package #:org.shirakumo.qtools.ui)
+(in-readtable :qtools)
+
+(define-widget auto-resizing-textedit (qtextedit qui:fixed-qtextedit)
+  ((minimum-lines :accessor minimum-lines :initarg :minimum-lines))
+  (:default-initargs :minimum-lines 1))
+
+(defmethod initialize-instance :after ((object auto-resizing-textedit) &key)
+  (let ((size-policy (q+:size-policy object)))
+    (setf (q+:height-for-width size-policy) T
+          (q+:vertical-policy size-policy) (q+:qsizepolicy.preferred)
+          (q+:size-policy object) size-policy))
+  (setf (minimum-lines object) (minimum-lines object)))
+
+(define-slot (auto-resizing-textedit update-geometry) ()
+  (declare (connected auto-resizing-textedit (text-changed)))
+  (q+:update-geometry auto-resizing-textedit))
+
+(defmethod (setf minimum-lines) :after (nlines (object auto-resizing-textedit))
+  (setf (q+:minimum-size object)
+        (values (q+:width (q+:minimum-size object))
+                (line-count-widget-height object nlines))))
+
+(defun height-for-width (auto-resizing-textedit width)
+  (let* ((margins (q+:contents-margins auto-resizing-textedit))
+         (document-width (if (>= width (+ (q+:left margins) (q+:right margins)))
+                             (- width (q+:left margins) (q+:right margins))
+                             0))
+         (document (q+:clone (q+:document auto-resizing-textedit))))
+    (setf (q+:text-width document) document-width)
+    (floor (+ (q+:top margins)
+              (q+:height (q+:size document))
+              (q+:bottom margins)))))
+
+(define-override (auto-resizing-textedit height-for-width) (width)
+  (height-for-width auto-resizing-textedit width))
+
+(define-override (auto-resizing-textedit size-hint) ()
+  (let* ((original-hint (call-next-qmethod))
+         (width (q+:width original-hint)))
+    (q+:make-qsize width (height-for-width auto-resizing-textedit width))))
+
+(defun line-count-widget-height (auto-resizing-textedit nlines)
+  (let* ((margins (q+:contents-margins auto-resizing-textedit))
+         (document (q+:document auto-resizing-textedit))
+         (document-margin (q+:document-margin document))
+         (font-metrics (q+:make-qfontmetrics (q+:default-font document))))
+    (floor (+ (q+:top margins)
+              document-margin
+              (* (max 1 nlines) (q+:height font-metrics))
+              document-margin
+              (q+:bottom margins)))))

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -7,6 +7,18 @@
 (in-package #:org.shirakumo.qtools.ui)
 (in-readtable :qtools)
 
+;; auto-resizing-textedit.lisp
+(docs:define-docs
+  (cl:function minimum-lines
+    "Accesses the minimum lines value of the auto-resizing text edit.")
+
+  (type auto-resizing-textedit
+    "A QTextEdit whose height automatically adjusts based on its text when it is
+placed inside a layout.
+
+The height computation assumes that only the standard font is used in the
+document."))
+
 ;; bytearray.lisp
 (docs:define-docs
   (cl:function from-byte-array

--- a/package.lisp
+++ b/package.lisp
@@ -9,6 +9,10 @@
 (defpackage #:qtools-ui
   (:nicknames #:qui #:org.shirakumo.qtools.ui)
   (:use #:cl+qt)
+  ;; auto-resizing-textedit.lisp
+  (:export
+   #:auto-resizing-textedit
+   #:minimum-lines)
   ;; bytearray.lisp
   (:export
    #:from-byte-array

--- a/qtools-ui-auto-resizing-textedit.asd
+++ b/qtools-ui-auto-resizing-textedit.asd
@@ -1,0 +1,18 @@
+#|
+ This file is a part of Qtools-UI
+ (c) 2020 Shirakumo http://tymoon.eu (shinmera@tymoon.eu)
+ Author: Michał "phoe" Herda <phoe@disroot.org>
+|#
+
+(asdf:defsystem qtools-ui-auto-resizing-textedit
+  :license "zlib"
+  :author "Michał \"phoe\" Herda <phoe@disroot.org>"
+  :maintainer "Michał \"phoe\" Herda <phoe@disroot.org>"
+  :description "QTextEdit with automatic height adjustment"
+  :homepage "https://Shinmera.github.io/qtools-ui/"
+  :bug-tracker "https://github.com/Shinmera/qtools-ui/issues"
+  :source-control (:git "https://github.com/Shinmera/qtools-ui.git")
+  :serial T
+  :components ((:file "auto-resizing-textedit"))
+  :depends-on (:qtools-ui-base
+               :qtools-ui-fixed-qtextedit))

--- a/qtools-ui.asd
+++ b/qtools-ui.asd
@@ -15,7 +15,8 @@
   :bug-tracker "https://github.com/Shinmera/qtools-ui/issues"
   :source-control (:git "https://github.com/Shinmera/qtools-ui.git")
   :serial T
-  :depends-on (:qtools-ui-base
+  :depends-on (:qtools-ui-auto-resizing-textedit
+               :qtools-ui-base
                :qtools-ui-cell
                :qtools-ui-color-history
                :qtools-ui-color-picker


### PR DESCRIPTION
This is a port of https://github.com/cameel/auto-resizing-text-edit

Test: the bottom is a red-hued QLabel told to occupy all available space.

![Zrzut ekranu z 2020-02-06 23-06-38](https://user-images.githubusercontent.com/15045546/73982871-66804c80-4935-11ea-8fd8-e82ff536d741.png)
![Zrzut ekranu z 2020-02-06 23-06-44](https://user-images.githubusercontent.com/15045546/73982870-65e7b600-4935-11ea-8ada-0ae55a586c82.png)
![Zrzut ekranu z 2020-02-06 23-06-48](https://user-images.githubusercontent.com/15045546/73982869-654f1f80-4935-11ea-9995-a52ffd20ccb9.png)